### PR TITLE
Update README.md as the old documentation has been deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LayerZero - an Omnichain Interoperability Protocol
 
-This repository contains the smart contracts for LayerZero Endpoints. For developers looking to build on top of LayerZero please refer to the [docs](https://layerzero.gitbook.io/docs/) 
+This repository contains the smart contracts for LayerZero Endpoints. For developers looking to build on top of LayerZero please refer to the [docs](https://docs.layerzero.network/v1) 
 
 ## Overview
 LayerZero is an Omnichain Interoperability Protocol designed for lightweight message passing across chains. LayerZero provides authentic and guaranteed message delivery with configurable trustlessness. The protocol is implemented as a set of gas-efficient, non-upgradable smart contracts.


### PR DESCRIPTION
updated the docs link in README.md and changed it to new because the old gitbook docs has been deprecated.

![Screenshot 2024-05-16 104959](https://github.com/LayerZero-Labs/LayerZero/assets/74761401/3d6e344d-ea09-4f97-a51a-7301722c606b)
